### PR TITLE
Deploy tagged builds to pypi. Fixes #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,17 @@ install:
   - python setup.py develop
 # command to run tests
 script:
+  - git describe
+  - find .
   - py.test --flakes --cov=loginsightexport --cov-config=tox.ini --cov-fail-under=40 --cov-report term-missing
 after_success: coveralls
+before_deploy:
+  - echo version=\"$TRAVIS_TAG\" > $TRAVIS_BUILD_DIR/loginsightexport/__version__.py
+deploy:
+  provider: pypi
+  user: alanjcastonguay
+  password:
+    secure: p+fl8//PVXl+5NSMTA0GGwv2HGv4z1DqMkU3rQ1QGpt7Qm8yLwLPPHkQ1tRktZh/Mv01koysKeST3PG9w66wW0r85NqaH2aKvL73+6I/7MYqds/963tWf7CfkGl8oNKYXx4/+RmfDLhQyMyeLVNsNFMl1bmUSq2HlnUyAiLhNLx9pm6lOjCZ7Lvb6lkxukOtvbbpEnhfj0zxMP0MLGy5/J0JYcwasyfUSdfQiHBygltxRIMVLI3HkZtLvVmfrzsXvnUgI8f91gKrGbabAwbvazTZwk0wNBxo9dWyn3trDwYhkUjn8tPiPNnGHvmzBT/DjBKnyUStx8Mdtz+o+GRwt2s1XdpqpaN980wld44x6peUOE0EAKXQ3oaOHWKXyL8wDsoZJmJa1oNRVse4GkvPCLvf9aBVVAT9hIN2QwSAcsTZzR6e9Arng91GKnHzFYcB6qm37Gx2E7tPHGZR2LBdR//DmI9XA+1XREhz3ypRNxe5oucmPAS/1eoyHu2u5c+iOYJAc++VQv6vtriIe+aOWR5mhshNz8uCA/v8mauh0c31MLqI8nCCsst3gXxDaPSKems09LsxScYfD9NyXy615TeOfp/Alw1TOxZx1xVq82FRhxZlcwKjUlDAeskWls9m522+yGiyGpRf6tVN2PIZf0OAqE4qDwVy/ti1VfoOfF8=
+  on:
+    tags: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ install:
   - python setup.py develop
 # command to run tests
 script:
-  - git describe
-  - find .
   - py.test --flakes --cov=loginsightexport --cov-config=tox.ini --cov-fail-under=40 --cov-report term-missing
 after_success: coveralls
 before_deploy:
+  - git describe
+  - echo TRAVIS_TAG $TRAVIS_TAG
   - echo version=\"$TRAVIS_TAG\" > $TRAVIS_BUILD_DIR/loginsightexport/__version__.py
 deploy:
   provider: pypi


### PR DESCRIPTION
When a commit is tagged, perform a build and release to pypi. The version number in the release is based on the tag.