### PR TITLE
Fix issue #15 - ignore aggregate query groups/functions

### DIFF
--- a/loginsightexport/paramhelper.py
+++ b/loginsightexport/paramhelper.py
@@ -209,13 +209,23 @@ class ExplorerUrlParse(object):
                 elif isinstance(s, list):
                     logger.debug("Mapping list-of-dict item %s = %s" % (_, str(s)))
 
-                    if _ in ["fieldConstraints", "extractedFields", "groupByFields"]:
+                    if _ in ["fieldConstraints", "extractedFields"]:
                         counter = 0
                         for listitem in s:
                             for fieldConstraintsDictKey in listitem:
                                 params['paramsHelper.%s[%d].%s' % (insertedkey, counter, fieldConstraintsDictKey)] = \
                                     listitem[fieldConstraintsDictKey]
                             counter += 1
+
+                    elif _ in ["groupByFields"]:
+                        logger.info("Ignoring group-by fields in chart query: %s" % s)
+
+                    elif insertedkey in ['funcGroups']:
+                        for listitem in s:
+                            if 'functions' in listitem.keys():
+                                logger.info("Ignoring group-by functions in chart query: %s" % listitem)
+                        params['paramsHelper.funcGroups[0].piqlFunctions[0]'] = 'COUNT'
+
                     else:
                         counter = 0
                         for listitem in s:

--- a/loginsightexport/uidriver.py
+++ b/loginsightexport/uidriver.py
@@ -394,8 +394,10 @@ class AggregateQuery(object):
 
         self.elapsed = r.elapsed
 
+        if len(body['groupByHeaders']) == 0:
+            raise RuntimeError("This query produced zero groupings. Set the query to group by time only.")
         if len(body['groupByHeaders']) != 1:
-            raise RuntimeError("This query produced multiple groupings. Set the query to group by time only.")
+            raise RuntimeError("This query produced multiple groupings (%s). Set the query to group by time only." % body['groupByHeaders'])
         if not body['groupByHeaders'][0]['isTime']:
             raise RuntimeError("This query is grouped by something other than time. Set the query to group by time only.")
 

--- a/tests/test_integration_bug_15.py
+++ b/tests/test_integration_bug_15.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from loginsightexport.paramhelper import ExplorerUrlParse
+from loginsightexport.uidriver import AggregateQuery
+
+# VMware vRealize Log Insight Exporter
+# Copyright © 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+def test_bug_15(ui):
+    """
+    Verify bug 15, where reading innerlistitem['value'] failed with TypeError
+    >>> params['paramsHelper.%s[%d].piqlFunctions[%d]' % (insertedkey, counter, second_counter)] = innerlistitem['value']
+    TypeError: string indices must be integers
+    """
+    u = "/explorer/?existingChartQuery=%7B%22query%22%3A%22%22%2C%22startTimeMillis%22%3A1510249336717%2C%22endTimeMillis%22%3A1510250503304%2C%22piqlFunctionGroups%22%3A%5B%7B%22functions%22%3A%5B%7B%22label%22%3A%22Unique%20count%22%2C%22value%22%3A%22UCOUNT%22%2C%22requiresField%22%3Atrue%2C%22numericOnly%22%3Afalse%7D%5D%2C%22field%22%3A%7B%22internalName%22%3A%22event_type%22%2C%22displayName%22%3A%22event_type%22%2C%22displayNamespace%22%3Anull%7D%7D%2C%7B%22functions%22%3A%5B%7B%22label%22%3A%22Count%22%2C%22value%22%3A%22COUNT%22%2C%22requiresField%22%3Afalse%2C%22numericOnly%22%3Afalse%7D%5D%2C%22field%22%3Anull%7D%5D%2C%22dateFilterPreset%22%3A%22ALL_TIME%22%2C%22shouldGroupByTime%22%3Atrue%2C%22eventSortOrder%22%3A%22DESC%22%2C%22summarySortOrder%22%3A%22DESC%22%2C%22compareQueryOrderBy%22%3A%22TREND%22%2C%22compareQuerySortOrder%22%3A%22DESC%22%2C%22compareQueryOptions%22%3Anull%2C%22messageViewType%22%3A%22EVENTS%22%2C%22constraintToggle%22%3A%22ALL%22%2C%22piqlFunction%22%3A%7B%22label%22%3A%22Unique%20count%22%2C%22value%22%3A%22UCOUNT%22%2C%22requiresField%22%3Atrue%2C%22numericOnly%22%3Afalse%7D%2C%22piqlFunctionField%22%3A%22event_type%22%2C%22fieldConstraints%22%3A%5B%5D%2C%22supplementalConstraints%22%3A%5B%5D%2C%22groupByFields%22%3A%5B%7B%22displayName%22%3A%22source%22%2C%22internalName%22%3A%22__li_source_path%22%2C%22displayNamespace%22%3Anull%2C%22numericGroupByType%22%3A%22EACH_VALUE%22%2C%22numericGroupByValue%22%3Anull%7D%2C%7B%22displayName%22%3A%22hostname%22%2C%22internalName%22%3A%22hostname%22%2C%22displayNamespace%22%3Anull%2C%22numericGroupByType%22%3A%22EACH_VALUE%22%2C%22numericGroupByValue%22%3Anull%7D%5D%2C%22extractedFields%22%3A%5B%5D%7D&chartOptions=%7B%22logaxis%22%3Afalse%2C%22legend%22%3Atrue%2C%22stacking%22%3A%22normal%22%7D"
+
+    root = ExplorerUrlParse(u)
+
+    generated_url = root.chartingurl_export(root.start, altend=root.end)
+
+    a = AggregateQuery(ui, generated_url)

--- a/tests/test_integration_group_by_more_than_just_time.py
+++ b/tests/test_integration_group_by_more_than_just_time.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from loginsightexport.binfit import patch_bins_at_boundaries, split, sorted_by_startTimeMillis
+from loginsightexport.paramhelper import ExplorerUrlParse
+from loginsightexport.uidriver import AggregateQuery
+
+# VMware vRealize Log Insight Exporter
+# Copyright © 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+def test_group_by_field_fails(ui):
+    u = "/explorer?existingChartQuery=%7B%22query%22%3A%22%22%2C%22startTimeMillis%22%3A1510249052377%2C%22endTimeMillis%22%3A1510249359662%2C%22piqlFunctionGroups%22%3A%5B%7B%22functions%22%3A%5B%7B%22label%22%3A%22Count%22%2C%22value%22%3A%22COUNT%22%2C%22requiresField%22%3Afalse%2C%22numericOnly%22%3Afalse%7D%5D%2C%22field%22%3Anull%7D%5D%2C%22dateFilterPreset%22%3A%22CUSTOM%22%2C%22shouldGroupByTime%22%3Atrue%2C%22eventSortOrder%22%3A%22DESC%22%2C%22summarySortOrder%22%3A%22DESC%22%2C%22compareQueryOrderBy%22%3A%22TREND%22%2C%22compareQuerySortOrder%22%3A%22DESC%22%2C%22compareQueryOptions%22%3Anull%2C%22messageViewType%22%3A%22EVENTS%22%2C%22constraintToggle%22%3A%22ALL%22%2C%22piqlFunction%22%3A%7B%22label%22%3A%22Count%22%2C%22value%22%3A%22COUNT%22%2C%22requiresField%22%3Afalse%2C%22numericOnly%22%3Afalse%7D%2C%22piqlFunctionField%22%3Anull%2C%22fieldConstraints%22%3A%5B%5D%2C%22supplementalConstraints%22%3A%5B%5D%2C%22groupByFields%22%3A%5B%7B%22displayName%22%3A%22source%22%2C%22internalName%22%3A%22__li_source_path%22%2C%22displayNamespace%22%3Anull%2C%22numericGroupByType%22%3A%22EACH_VALUE%22%2C%22numericGroupByValue%22%3Anull%7D%2C%7B%22displayName%22%3A%22hostname%22%2C%22internalName%22%3A%22hostname%22%2C%22displayNamespace%22%3Anull%2C%22numericGroupByType%22%3A%22EACH_VALUE%22%2C%22numericGroupByValue%22%3Anull%7D%5D%2C%22extractedFields%22%3A%5B%5D%7D&chartOptions=%7B%22logaxis%22%3Afalse%2C%22legend%22%3Atrue%2C%22stacking%22%3A%22normal%22%2C%22spline%22%3Afalse%7D"
+
+    root = ExplorerUrlParse(u)
+
+    def retrieve_aggregate_results(bin=(None, None, None), report_callback=True):
+        if report_callback:
+            raise RuntimeError("Can't callback")
+        a = AggregateQuery(ui, root.chartingurl_export(altstart=bin[0], altend=bin[1]))
+        return sorted_by_startTimeMillis(patch_bins_at_boundaries(bin, a.bins))
+
+    overview = retrieve_aggregate_results((root.start, root.end, 0), False)
+    expanded_bins = list(split(overview, retrieve_aggregate_results))
+    print(expanded_bins)

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ norecursedirs = build dist export .cache .coverage .eggs .env .idea .tox Experim
 pep8ignore =
     *.py E501
     .tox ALL
+    setup.exe.py ALL
 
 log_format = %(asctime)s %(name)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
@@ -29,3 +30,4 @@ log_cli_date_format = %Y-%m-%d %H:%M:%S
 flakes-ignore =
     .tox ALL
     tests/*.py UnusedVariable
+    setup.exe.py ALL


### PR DESCRIPTION
Aggregate queries can contain functions to execute over
groups of fields, producing a numeric series. During export,
we only need COUNT(timestamp), so drop other functions
and fields from the query.